### PR TITLE
Add PV to slurm controller

### DIFF
--- a/internal/controller/controller_node_controller.go
+++ b/internal/controller/controller_node_controller.go
@@ -66,12 +66,7 @@ func generateControllerNodeStatefulSet(cluster slurmv1alpha1.Cluster, spec slurm
 						},
 					},
 					Volumes: []corev1.Volume{
-						{
-							Name: "slurm-spool",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
+						renderSlurmCtrlSpoolVolume(cluster),
 						renderSSSDConfigVolume(cluster.Name),
 						renderSSSLibVolume(),
 						renderHomeDirVolume(cluster),

--- a/internal/controller/render.go
+++ b/internal/controller/render.go
@@ -180,3 +180,14 @@ func renderSlurmConfigVolume(cluster slurmv1alpha1.Cluster, withGres bool) corev
 	}
 	return vol
 }
+
+func renderSlurmCtrlSpoolVolume(cluster slurmv1alpha1.Cluster) corev1.Volume {
+	return corev1.Volume{
+		Name: "slurm-spool",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "slurm-ctrl-spool",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Slurm stores the state in the spool directory, so a PV is required