### PR TITLE
Add PV to slurm controller

### DIFF
--- a/internal/controller/render.go
+++ b/internal/controller/render.go
@@ -180,3 +180,14 @@ func renderSlurmConfigVolume(cluster slurmv1alpha1.Cluster, withGres bool) corev
 	}
 	return vol
 }
+
+func renderSlurmCtrlSpoolVolume(pvcName string) corev1.Volume {
+	return corev1.Volume{
+		Name: "slurm-spool",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	}
+}

--- a/internal/utils/naming.go
+++ b/internal/utils/naming.go
@@ -66,7 +66,7 @@ func BuildServiceHostFQDN(
 	return hostName, hostFQDN
 }
 
-func BildPersistentVolumeClaimName(componentType consts.ComponentType, clusterName string) string {
+func BuildPersistentVolumeClaimName(componentType consts.ComponentType, clusterName string) string {
 	return namedEntity{
 		componentType: &componentType,
 		clusterName:   clusterName,


### PR DESCRIPTION
Slurm controller stores the state in the spool directory, so a PV is required.